### PR TITLE
Add step-based navigation to LMRA form

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,8 @@ Ensuite, l’app peut fonctionner hors-ligne.`,
     send: "Envoyer",
     sending: "Envoi en cours…",
     queue_label: "File",
+    prev: "Précédent",
+    next: "Suivant",
 
     // Alerts
     alert_sent: "Envoyé ✅",
@@ -243,6 +245,8 @@ Then, the app can work offline.`,
     send: "Send",
     sending: "Sending…",
     queue_label: "Queue",
+    prev: "Previous",
+    next: "Next",
 
     alert_sent: "Sent ✅",
     alert_offline_queued: "No network: saved locally. Will auto-send when online.",
@@ -408,6 +412,8 @@ Daarna kan de app offline werken.`,
     send: "Verzenden",
     sending: "Verzenden…",
     queue_label: "Wachtrij",
+    prev: "Vorige",
+    next: "Volgende",
 
     alert_sent: "Verzonden ✅",
     alert_offline_queued: "Geen netwerk: lokaal opgeslagen. Wordt automatisch verzonden zodra online.",
@@ -786,10 +792,12 @@ const MAP_KEYS = {
     });
 
     const [data, setData] = React.useState(loadLS(STATE_KEY, initialState()));
+    const [step, setStep] = React.useState(0);
+    const totalSteps = 6;
     React.useEffect(()=>{ saveLS(STATE_KEY, data); }, [data]);
 
     const setField = (k,v)=>setData({...data,[k]:v});
-    const resetAll = () => setData(initialState());
+    const resetAll = () => { setData(initialState()); setStep(0); };
 
     const envoyer = async () => {
       const payload = {
@@ -803,6 +811,7 @@ const MAP_KEYS = {
         saveLS(PREFS_KEY, { responsable:data.responsable, team:data.team });
         // Reset du reste, en ré-injectant prefs
         setData(initialState());
+        setStep(0);
       }else{
         enqueueOutbox(payload);
         alert(t('alert_offline_queued'));
@@ -817,9 +826,16 @@ const MAP_KEYS = {
           <button onClick={resetAll} className="px-3 py-2 rounded-xl border">{t('reset_all')}</button>
           <div className="text-xs text-gray-500 mt-1">{t('reset_hint_team')}</div>
         </div>
+        <div className="mb-4">
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div className="bg-black h-2 rounded-full" style={{width: `${((step+1)/totalSteps)*100}%`}}></div>
+          </div>
+          <div className="text-center text-xs mt-1">{step+1}/{totalSteps}</div>
+        </div>
 
-        <Section title={t('general_info')}>
-          <div className="flex flex-col gap-3">
+        {step===0 && (
+          <Section title={t('general_info')}>
+            <div className="flex flex-col gap-3">
             <label className="text-sm">{t('datetime')}
               <input type="datetime-local" value={data.datetime} onChange={(e)=>setField("datetime", e.target.value)} className="mt-1 w-full px-3 py-2 rounded-xl border" />
             </label>
@@ -852,7 +868,9 @@ const MAP_KEYS = {
             </div>
           </div>
         </Section>
+        )}
 
+        {step===1 && (
         <Section title={t('cond_title')}>
           <div className="flex flex-col gap-3">
             <Toggle checked={data.conditions.tacheClaires} onChange={(v)=>setData({...data, conditions:{...data.conditions, tacheClaires:v}})} label={t('cond_task_clear')} />
@@ -877,7 +895,9 @@ const MAP_KEYS = {
             </div>
           </div>
         </Section>
+        )}
 
+        {step===2 && (
         <Section title={t('risks_title')}>
           <div className="flex flex-col gap-3">
             {/* Énergies */}
@@ -945,7 +965,9 @@ const MAP_KEYS = {
             </div>
           </div>
         </Section>
+        )}
 
+        {step===3 && (
         <Section title={t('measures_title')}>
           <div className="grid grid-cols-2 gap-2">
             {[
@@ -972,7 +994,9 @@ const MAP_KEYS = {
             )}
           </div>
         </Section>
+        )}
 
+        {step===4 && (
         <Section title={t('top3_title')}>
           <div className="flex flex-col gap-2">
             {data.top3.map((it,i)=>(
@@ -986,7 +1010,9 @@ const MAP_KEYS = {
             ))}
           </div>
         </Section>
+        )}
 
+        {step===5 && (
         <Section title={t('decision_title')}>
           <div className="flex flex-col gap-3">
             <div className="flex items-center gap-3">
@@ -1007,9 +1033,17 @@ const MAP_KEYS = {
             </label>
           </div>
         </Section>
+        )}
 
-        <div className="grid grid-cols-1 gap-2 mt-4">
-          <button onClick={envoyer} className="px-4 py-3 rounded-xl border bg-black text-white">{t('send')}</button>
+        <div className={"flex mt-4 " + (step>0 ? "justify-between" : "justify-end")}>
+          {step>0 && (
+            <button onClick={()=>setStep(step-1)} className="px-3 py-2 rounded-xl border">{t('prev')}</button>
+          )}
+          {step<totalSteps-1 ? (
+            <button onClick={()=>setStep(step+1)} className="px-3 py-2 rounded-xl border">{t('next')}</button>
+          ) : (
+            <button onClick={envoyer} className="px-4 py-3 rounded-xl border bg-black text-white">{t('send')}</button>
+          )}
         </div>
       </main>
     );


### PR DESCRIPTION
## Summary
- Add step state to LMRA screen and split form into sequential sections
- Show progress bar and Prev/Next navigation with localized labels
- Reset step after form reset or submit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b848691b508323ad779047de39782f