### PR TITLE
chore: bump service worker cache version

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () =>
-        navigator.serviceWorker.register('./sw.js?v=v4-borders-3').catch(console.error)
+        navigator.serviceWorker.register('./sw.js?v=v5').catch(console.error)
       );
     }
   </script>

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,8 @@
-// sw.js — QHSE PWA (cache statique + dynamique) — v4-logos-THICK2
-const CACHE_STATIC  = 'qhse-static-v4-borders-3';
-const CACHE_DYNAMIC = 'qhse-dyn-v4-borders-3';
+// sw.js — QHSE PWA (cache statique + dynamique) — v5
+const CACHE_STATIC  = 'qhse-static-v5';
+const CACHE_DYNAMIC = 'qhse-dyn-v5';
 
 const ASSETS = [
-  './',
-  './index.html',
   './sw.js',
   './manifest.webmanifest',
   './icon-192.png',


### PR DESCRIPTION
## Summary
- remove root and index from precache assets so they default to network-first
- bump cache identifiers and service worker version to `v5`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b44a484832382f5e293214bb97b