### PR TITLE
Load app without build step and add Cypress smoke test

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  e2e: {
+    baseUrl: 'http://localhost:8080',
+  }
+};

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -1,0 +1,6 @@
+describe('Home page', () => {
+  it('shows the home title', () => {
+    cy.visit('index.html');
+    cy.contains('QHSE – Apps chantier').should('be.visible');
+  });
+});

--- a/index.html
+++ b/index.html
@@ -28,7 +28,10 @@
       );
     }
   </script>
-
-  <script src="dist/bundle.js"></script>
+  <!-- React + Babel for direct browser execution -->
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script type="text/babel" data-presets="react,env" src="src/main.jsx"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "sw.js",
   "scripts": {
     "build": "webpack",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "cypress:run": "cypress run"
   },
   "keywords": [],
   "author": "",
@@ -21,6 +22,7 @@
     "babel-loader": "^9.1.3",
     "@babel/core": "^7.22.20",
     "@babel/preset-env": "^7.22.20",
-    "@babel/preset-react": "^7.22.5"
+    "@babel/preset-react": "^7.22.5",
+    "cypress": "^13.6.2"
   }
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
+const React = window.React;
+const ReactDOM = window.ReactDOM;
 
     // ========================= CONFIG =========================
     // ⬇⬇ Remplacer l' URL Apps Script /exec si modification du GSheet


### PR DESCRIPTION
## Summary
- load React from CDN and compile JSX in browser to avoid blank page
- add Cypress configuration and home page smoke test

## Testing
- `npm test` (fails: no test specified)
- `npx cypress run` (fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)


------
https://chatgpt.com/codex/tasks/task_e_68b8548f8f248323a87e93d2a4a1174d