### PR TITLE
Auto-add LMRA team member when input not added

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -760,6 +760,14 @@ const MAP_KEYS = {
 
     const next = () => {
       if(step === 0){
+        const name = data.teamInput.trim();
+        if(name){
+          if(data.team.includes(name)){
+            setData({...data, teamInput:""});
+          }else{
+            setData({...data, team:[...data.team, name], teamInput:""});
+          }
+        }
         const missing = { site: !data.site.trim(), responsable: !data.responsable.trim() };
         setErrors(missing);
         if(missing.site || missing.responsable){


### PR DESCRIPTION
## Summary
- automatically add typed team member when proceeding without clicking Add

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b89b48a06083238ea0df49fcf020ac