### PR TITLE
Add dropdown for metier selection

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -44,7 +44,12 @@
 
     <section class="bg-white rounded shadow p-4">
       <label for="metier" class="block text-sm font-medium mb-1">Métier</label>
-      <input id="metier" type="text" class="border rounded px-2 py-1 w-full">
+      <select id="metier" class="border rounded px-2 py-1 w-full">
+        <option value="">Sélectionnez...</option>
+        <option value="Elec.">Elec.</option>
+        <option value="HVAC">HVAC</option>
+        <option value="Ref.">Ref.</option>
+      </select>
     </section>
 
     <section class="bg-white rounded shadow p-4">


### PR DESCRIPTION
## Summary
- replace free-text métier input with a dropdown list
- include options for Elec., HVAC and Ref.

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba736dc07c83239361e21615a03396