### PR TITLE
Handle missing métier data in TBM form

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -231,8 +231,12 @@
       const date = new Date(dateInput.value);
       if(!equipeData){
         loadStatus.textContent = 'Sélectionnez un métier';
+        chantierSelect.disabled = true;
+        responsableSelect.disabled = true;
         return;
       }
+      chantierSelect.disabled = false;
+      responsableSelect.disabled = true;
       const col = findColumnIndex(equipeData,date);
       if(col===-1){
         loadStatus.textContent = 'Aucun chantier disponible pour cette date';
@@ -355,6 +359,7 @@
           equipeSheets[metier] = data;
         }catch(e){
           console.error(e);
+          loadStatus.textContent = "Impossible de charger les données pour ce métier";
         }
       }
       equipeData = equipeSheets[metier] || null;


### PR DESCRIPTION
## Summary
- Show an error when métier-specific data fails to load
- Disable chantier and responsable selectors until métier data is available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68baaedb8c088323ab3e91a25d2dac5a