### PR TITLE
feat: add TBM sheet handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,39 @@
+const TBM_SHEET_NAME = 'tbm';
+
+function doPost(e) {
+  const { meta = {}, data = {}, type } = JSON.parse(e.postData.contents);
+  if (type === 'tbm') return handleTbm(meta, data);
+  return respond({ ok: false, error: 'unknown type', type });
+}
+
+function handleTbm(meta, d) {
+  const headers = ['sentAt','datetime','metier','chantier','responsable','equipe','youtubeUrl','userAgent','payloadJson'];
+  const sh = getSheetByNameOrCreate(TBM_SHEET_NAME, headers);
+  const row = [
+    new Date().toISOString(),
+    d.datetime || '',
+    d.metier || '',
+    d.chantier || '',
+    d.responsable || '',
+    Array.isArray(d.equipe) ? d.equipe.join('|') : '',
+    d.youtubeUrl || '',
+    meta.userAgent || '',
+    JSON.stringify(d)
+  ];
+  sh.appendRow(row);
+  return respond({ ok: true, sheet: TBM_SHEET_NAME, row: sh.getLastRow() });
+}
+
+function getSheetByNameOrCreate(name, headers) {
+  const ss = SpreadsheetApp.getActive();
+  let sh = ss.getSheetByName(name);
+  if (!sh) {
+    sh = ss.insertSheet(name);
+    sh.appendRow(headers);
+  }
+  return sh;
+}
+
+function respond(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(ContentService.MimeType.JSON);
+}


### PR DESCRIPTION
## Summary
- log TBM submissions in Google Sheets via Apps Script handler
- ignore node modules in version control

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bea5a781e4832399eb523bc3d6b8b4