### PR TITLE
Allow free text entry for responsable field

### DIFF
--- a/cypress/e2e/responsable_select.cy.js
+++ b/cypress/e2e/responsable_select.cy.js
@@ -1,14 +1,18 @@
-describe('Responsable select', () => {
-  it('updates options with chantier and allows single choice', () => {
+describe('Responsable input', () => {
+  it('suggests responsables per chantier and allows free entry', () => {
     cy.visit('index.html#lmra');
     cy.get('input[name="site"]').type('Chantier A');
-    cy.get('select[name="responsable"] option').contains('Alice').should('exist');
-    cy.get('select[name="responsable"]').select('Alice');
+    cy.get('input[name="responsable"]').invoke('attr', 'list').then((id) => {
+      cy.get(`datalist#${id} option[value="Alice"]`).should('exist');
+    });
+    cy.get('input[name="responsable"]').type('Alice');
     cy.get('input[name="site"]').clear().type('Chantier B');
-    cy.get('select[name="responsable"]').should('have.value', '');
-    cy.get('select[name="responsable"] option').contains('Alice').should('not.exist');
-    cy.get('select[name="responsable"] option').contains('Brigitte').should('exist');
-    cy.get('select[name="responsable"]').select('Brigitte');
-    cy.get('select[name="responsable"] option:selected').should('have.length', 1);
+    cy.get('input[name="responsable"]').should('have.value', '');
+    cy.get('input[name="responsable"]').invoke('attr', 'list').then((id) => {
+      cy.get(`datalist#${id} option[value="Alice"]`).should('not.exist');
+      cy.get(`datalist#${id} option[value="Brigitte"]`).should('exist');
+    });
+    cy.get('input[name="responsable"]').type('Brigitte');
+    cy.get('input[name="responsable"]').should('have.value', 'Brigitte');
   });
 });

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -844,10 +844,10 @@ const MAP_KEYS = {
               <input value={data.task} onChange={(e)=>setField("task", e.target.value)} placeholder={t('task_ph')} className="mt-1 w-full px-3 py-2 rounded-xl border" />
             </label>
             <label className="text-sm">{t('manager')}
-              <select name="responsable" value={data.responsable} onChange={(e)=>{ setField("responsable", e.target.value); if(errors.responsable) setErrors({...errors, responsable:false}); }} className={`mt-1 w-full px-3 py-2 rounded-xl border ${errors.responsable? 'border-red-500':''}`} required>
-                <option value="">{t('manager_ph')}</option>
-                {(RESPONSABLES_PAR_CHANTIER[data.site || data.chantier] || []).map(n => <option key={n} value={n}>{n}</option>)}
-              </select>
+              <input list="responsables-lmra" name="responsable" value={data.responsable} onChange={(e)=>{ setField("responsable", e.target.value); if(errors.responsable) setErrors({...errors, responsable:false}); }} placeholder={t('manager_ph')} className={`mt-1 w-full px-3 py-2 rounded-xl border ${errors.responsable? 'border-red-500':''}`} required />
+              <datalist id="responsables-lmra">
+                {(RESPONSABLES_PAR_CHANTIER[data.site || data.chantier] || []).map(n => <option key={n} value={n} />)}
+              </datalist>
               {errors.responsable && <div className="text-red-600 text-xs mt-1">{t('required_field')}</div>}
             </label>
 
@@ -1123,10 +1123,10 @@ const MAP_KEYS = {
               {errors.chantier && <div className="text-red-600 text-xs mt-1">{t('required_field')}</div>}
             </label>
             <label className="text-sm">{t('manager')}
-              <select name="responsable" value={data.responsable} onChange={(e)=>{ setField("responsable", e.target.value); if(errors.responsable) setErrors({...errors, responsable:false}); }} className={`mt-1 w-full px-3 py-2 rounded-xl border ${errors.responsable? 'border-red-500':''}`} required>
-                <option value="">{t('manager_ph')}</option>
-                {(RESPONSABLES_PAR_CHANTIER[data.site || data.chantier] || []).map(n => <option key={n} value={n}>{n}</option>)}
-              </select>
+              <input list="responsables-fa" name="responsable" value={data.responsable} onChange={(e)=>{ setField("responsable", e.target.value); if(errors.responsable) setErrors({...errors, responsable:false}); }} placeholder={t('manager_ph')} className={`mt-1 w-full px-3 py-2 rounded-xl border ${errors.responsable? 'border-red-500':''}`} required />
+              <datalist id="responsables-fa">
+                {(RESPONSABLES_PAR_CHANTIER[data.site || data.chantier] || []).map(n => <option key={n} value={n} />)}
+              </datalist>
               {errors.responsable && <div className="text-red-600 text-xs mt-1">{t('required_field')}</div>}
             </label>
             <label className="text-sm">{t('person')}
@@ -1311,10 +1311,10 @@ const MAP_KEYS = {
               {errors.chantier && <div className="text-red-600 text-xs mt-1">{t('required_field')}</div>}
             </label>
             <label className="text-sm">{t('manager')}
-              <select name="responsable" value={data.responsable} onChange={(e)=>{ setField("responsable", e.target.value); if(errors.responsable) setErrors({...errors, responsable:false}); }} className={`mt-1 w-full px-3 py-2 rounded-xl border ${errors.responsable? 'border-red-500':''}`} required>
-                <option value="">{t('manager_ph')}</option>
-                {(RESPONSABLES_PAR_CHANTIER[data.site || data.chantier] || []).map(n => <option key={n} value={n}>{n}</option>)}
-              </select>
+              <input list="responsables-stop" name="responsable" value={data.responsable} onChange={(e)=>{ setField("responsable", e.target.value); if(errors.responsable) setErrors({...errors, responsable:false}); }} placeholder={t('manager_ph')} className={`mt-1 w-full px-3 py-2 rounded-xl border ${errors.responsable? 'border-red-500':''}`} required />
+              <datalist id="responsables-stop">
+                {(RESPONSABLES_PAR_CHANTIER[data.site || data.chantier] || []).map(n => <option key={n} value={n} />)}
+              </datalist>
               {errors.responsable && <div className="text-red-600 text-xs mt-1">{t('required_field')}</div>}
             </label>
           </div>


### PR DESCRIPTION
## Summary
- allow custom text input for responsable in LMRA, first aid, and stop forms
- provide datalist suggestions based on chantier
- adjust Cypress test to validate new behaviour

## Testing
- `npm run cypress:run` *(fails: Your system is missing the dependency: Xvfb)*


------
https://chatgpt.com/codex/tasks/task_e_68beac1c4848832390b004866e66d4da