### PR TITLE
Prevent double TBM submission

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -479,6 +479,8 @@
     });
 
     sendBtn.addEventListener('click',async()=>{
+      sendBtn.disabled=true;
+      sendStatus.textContent='Envoi en cours…';
       const dateVal=dateInput.value;
       const metier=metierInput.value.trim();
       const chantier=chantierSelect.value;
@@ -486,6 +488,7 @@
       const members=[...teamContainer.querySelectorAll('input[type="checkbox"]:checked')].map(b=>b.value).concat(manualMembers);
       if(!dateVal||!metier||!chantier||!responsable||!members.length||!lastVideoUrl){
         sendStatus.textContent='Veuillez remplir tous les champs.';
+        sendBtn.disabled=false;
         return;
       }
       const payload={
@@ -495,12 +498,15 @@
       };
       try{
         await fetch(COLLECT_URL,{method:'POST',mode:'no-cors',headers:{'Content-Type':'text/plain'},body:JSON.stringify(payload)});
-        sendStatus.textContent='Envoyé';
+        sendStatus.textContent='Bien envoyé';
         teamContainer.querySelectorAll('input[type="checkbox"]').forEach(b=>b.checked=false);
         manualMembers=[];manualChips.innerHTML='';
       }catch(e){
         sendStatus.textContent="Erreur d'envoi, enregistré localement.";
         enqueue(payload);
+        sendBtn.disabled=false;
+      }finally{
+        sendBtn.disabled=false;
       }
       const entries=JSON.parse(localStorage.getItem('tbmEntries')||'[]');
       entries.push({


### PR DESCRIPTION
## Summary
- Disable TBM send button during submission
- Show progress and success messages for TBM send status

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bed2f1e9348323aab28da93d524b96