### PR TITLE
Add client-side required-field validation and visual error indicators for TBM form

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -192,6 +192,60 @@
     let manualMembers = [];
     const normalizedNameMap = new Map();
     let lastVideoUrl = '';
+    let hasAttemptedSubmit = false;
+
+    function markInvalidField(element, invalid){
+      if(!element) return;
+      element.classList.toggle('border-red-500', invalid);
+      element.classList.toggle('ring-1', invalid);
+      element.classList.toggle('ring-red-500', invalid);
+    }
+
+    function clearAllFieldErrors(){
+      [
+        dateInput,
+        metierInput,
+        chantierSelect,
+        chantierManualInput,
+        responsableSelect,
+        responsableManualInput,
+        teamContainer,
+        thumbContainer
+      ].forEach(el=>markInvalidField(el, false));
+    }
+
+    function validateRequiredFields(showErrors = false){
+      const dateVal = dateInput.value;
+      const metier = metierInput.value.trim();
+      const chantier = chantierManualInput.value.trim() || chantierSelect.value;
+      const responsable = responsableManualInput.value.trim() || (responsableSelect.disabled ? '' : responsableSelect.value);
+      const members = [...teamContainer.querySelectorAll('input[type="checkbox"]:checked')].map(b=>b.value).concat(manualMembers);
+
+      const missing = {
+        date: !dateVal,
+        metier: !metier,
+        chantier: !chantier,
+        responsable: !responsable,
+        members: !members.length,
+        video: !lastVideoUrl
+      };
+
+      const chantierMissing = missing.chantier;
+      const responsableMissing = missing.responsable;
+
+      if(showErrors){
+        markInvalidField(dateInput, missing.date);
+        markInvalidField(metierInput, missing.metier);
+        markInvalidField(chantierSelect, chantierMissing);
+        markInvalidField(chantierManualInput, chantierMissing);
+        markInvalidField(responsableSelect, responsableMissing);
+        markInvalidField(responsableManualInput, responsableMissing);
+        markInvalidField(teamContainer, missing.members);
+        markInvalidField(thumbContainer, missing.video);
+      }
+
+      return { missing, dateVal, metier, chantier, responsable, members };
+    }
 
     function enqueue(item){
       const queue = JSON.parse(localStorage.getItem(OUTBOX_KEY) || '[]');
@@ -500,6 +554,7 @@
       updateKnownNamesFromRows(base);
       populateChantiers();
       populateVideo();
+      if(hasAttemptedSubmit) validateRequiredFields(true);
     }
 
     function cleanHeaderCell(s){
@@ -606,6 +661,7 @@
       x.addEventListener('click',()=>{
         manualMembers=manualMembers.filter(m=>m!==name);
         chip.remove();
+        if(hasAttemptedSubmit) validateRequiredFields(true);
       });
       chip.appendChild(x);
       manualChips.appendChild(chip);
@@ -646,12 +702,14 @@
       const boxes = teamContainer.querySelectorAll('input[type="checkbox"]');
       const allChecked = Array.from(boxes).every(b=>b.checked);
       boxes.forEach(b=>b.checked=!allChecked);
+      if(hasAttemptedSubmit) validateRequiredFields(true);
     });
+    teamContainer.addEventListener('change', ()=>{ if(hasAttemptedSubmit) validateRequiredFields(true); });
 
     // ✅ listeners
-    metierInput.addEventListener('change', updateAll);
-    chantierSelect.addEventListener('change', populateResponsablesForChantier);
-    responsableSelect.addEventListener('change', populateTeamForSelectedResponsable);
+    metierInput.addEventListener('change', ()=>{ updateAll(); if(hasAttemptedSubmit) validateRequiredFields(true); });
+    chantierSelect.addEventListener('change', ()=>{ populateResponsablesForChantier(); if(hasAttemptedSubmit) validateRequiredFields(true); });
+    responsableSelect.addEventListener('change', ()=>{ populateTeamForSelectedResponsable(); if(hasAttemptedSubmit) validateRequiredFields(true); });
 
     chantierManualInput.addEventListener('input',()=>{
       if(chantierManualInput.value.trim()){
@@ -665,6 +723,7 @@
         chantierSelect.disabled=false;
         populateChantiers();
       }
+      if(hasAttemptedSubmit) validateRequiredFields(true);
     });
 
     responsableManualInput.addEventListener('input',()=>{
@@ -675,16 +734,17 @@
         responsableSelect.disabled=false;
       }
       populateTeamForSelectedResponsable();
+      if(hasAttemptedSubmit) validateRequiredFields(true);
     });
 
-    dateInput.addEventListener('change', updateAll);
+    dateInput.addEventListener('change', ()=>{ updateAll(); if(hasAttemptedSubmit) validateRequiredFields(true); });
 
     manualInput.addEventListener('keydown',e=>{
       if(e.key==='Enter'){ e.preventDefault(); addManual(); manualInput.focus(); }
     });
-    manualInput.addEventListener('blur',addManual);
+    manualInput.addEventListener('blur',()=>{ addManual(); if(hasAttemptedSubmit) validateRequiredFields(true); });
     manualInput.addEventListener('input',()=> setManualError(''));
-    manualAddBtn.addEventListener('click',()=>{ addManual(); manualInput.focus(); });
+    manualAddBtn.addEventListener('click',()=>{ addManual(); if(hasAttemptedSubmit) validateRequiredFields(true); manualInput.focus(); });
 
     playBtn.addEventListener('click',()=>{ if(lastVideoUrl) window.open(lastVideoUrl, '_blank'); });
     copyLinkBtn.addEventListener('click',async()=>{ if(!lastVideoUrl) return; try{await navigator.clipboard.writeText(lastVideoUrl);}catch{} });
@@ -783,13 +843,9 @@
     });
 
     sendBtn.addEventListener('click',()=>{
-      const dateVal=dateInput.value;
-      const metier=metierInput.value.trim();
-      const chantier=chantierManualInput.value.trim()||chantierSelect.value;
-      const responsable=responsableManualInput.value.trim()||(responsableSelect.disabled?'':responsableSelect.value);
-      const members=[...teamContainer.querySelectorAll('input[type="checkbox"]:checked')].map(b=>b.value).concat(manualMembers);
-
-      if(!dateVal||!metier||!chantier||!responsable||!members.length||!lastVideoUrl){
+      hasAttemptedSubmit = true;
+      const { missing, dateVal, metier, chantier, responsable, members } = validateRequiredFields(true);
+      if(Object.values(missing).some(Boolean)){
         sendStatus.textContent='Veuillez remplir tous les champs.';
         return;
       }
@@ -800,6 +856,8 @@
         data:{datetime:dateVal,metier,chantier,responsable,equipe:members,youtubeUrl:lastVideoUrl}
       };
       sendStatus.textContent='';
+      clearAllFieldErrors();
+      hasAttemptedSubmit = false;
       showConfirmation({
         message:'Voulez-vous envoyer ?',
         confirmLabel:'Confirmer',


### PR DESCRIPTION
### Motivation
- Provide immediate client-side validation for the TBM submission form so users get visual feedback on missing required fields before submitting.
- Prevent incomplete submissions by gating the confirmation flow on validated inputs.

### Description
- Added a `hasAttemptedSubmit` flag plus `validateRequiredFields(showErrors)` to compute missing fields and optionally mark UI controls as invalid. 
- Implemented `markInvalidField` and `clearAllFieldErrors` to toggle error styles on inputs/containers and wired validation to key UI events (field changes, manual additions, team toggles). 
- Updated the `sendBtn` handler to run `validateRequiredFields(true)`, show an error message when fields are missing, and only proceed to `showConfirmation` when validation passes; `clearAllFieldErrors` is called before confirmation. 
- Minor UX hooks: re-validate on manual chip removal, team changes, and inputs that previously changed without validation calls.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de321e0b7c8323a0016f934f48845e)