### PR TITLE
Robust CSV parsing for AFFECTATIONS: required headers + safe cell readers

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -535,29 +535,40 @@
           row: findHeaderIndex(headers, ['row', 'ligne'])
         };
 
-        const missing = Object.entries(idx).filter(([k,v])=>v < 0).map(([k])=>k);
-        if(missing.length){
+        const requiredKeys = ['semaine', 'chantier', 'sheet'];
+        const missingRequired = requiredKeys.filter((k)=>idx[k] < 0);
+        if(missingRequired.length){
           console.error('Headers raw:', headersRaw);
           console.error('Headers clean:', headers);
-          throw new Error(`En-têtes AFFECTATIONS manquants: ${missing.join(', ')}`);
+          throw new Error(`En-têtes AFFECTATIONS manquants: ${missingRequired.join(', ')}`);
         }
+
+        const readCell = (row, index, fallback = '') => {
+          if(index < 0) return fallback;
+          return (row[index] ?? fallback).toString().trim();
+        };
+        const readInt = (row, index) => {
+          if(index < 0) return null;
+          const v = parseInt(row[index],10);
+          return Number.isNaN(v) ? null : v;
+        };
 
         affectRows = raw.slice(1)
           .filter(r => r && r.length)
           .map(r => {
-            const sheet = (r[idx.sheet] || '').toString().trim();
+            const sheet = readCell(r, idx.sheet, '');
             return {
-              annee: parseInt(r[idx.annee],10) || null,
-              semaine: parseInt(r[idx.semaine],10) || null,
-              pm: (r[idx.pm] || '').toString().trim(),
-              sisu: (r[idx.sisu] || '').toString().trim(),
-              ce: (r[idx.ce] || '').toString().trim(),
-              ouvrier: (r[idx.ouvrier] || '').toString().trim(),
-              chantier: (r[idx.chantier] || '').toString().trim(),
-              nbColonnes: parseInt(r[idx.nbColonnes],10) || null,
+              annee: readInt(r, idx.annee),
+              semaine: readInt(r, idx.semaine),
+              pm: readCell(r, idx.pm, ''),
+              sisu: readCell(r, idx.sisu, ''),
+              ce: readCell(r, idx.ce, ''),
+              ouvrier: readCell(r, idx.ouvrier, ''),
+              chantier: readCell(r, idx.chantier, ''),
+              nbColonnes: readInt(r, idx.nbColonnes),
               sheet,
               sheetNorm: normalizeSheetName(sheet),
-              row: parseInt(r[idx.row],10) || null
+              row: readInt(r, idx.row)
             };
           })
           // ✅ garder lignes chantier même si ouvrier est vide (CE/PM)


### PR DESCRIPTION
### Motivation

- Prevent brittle failure when optional CSV headers are missing and avoid incorrect falsy handling of numeric values when parsing AFFECTATIONS rows.
- Normalize and trim cell reads consistently to reduce runtime errors from undefined cells.

### Description

- Restrict header validation to required keys `semaine`, `chantier`, and `sheet` and throw a clearer error when they are missing.
- Add helpers `readCell` and `readInt` to safely read and trim string cells and to parse integers while preserving `0` and returning `null` only for non-numeric values.
- Replace inline parsing in the `affectRows` mapping with `readCell`/`readInt` and normalize `sheet` into `sheetNorm` as before.
- Keep the filtering rule to retain chantier rows even if `ouvrier` is empty while ensuring rows have `semaine`, `chantier`, and `sheetNorm`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de321e0b7c8323a0016f934f48845e)