### PR TITLE
Changer le libellé d'annulation dans la confirmation de vidage d'historique

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -837,7 +837,7 @@
       showConfirmation({
         message:"Voulez-vous vraiment vider l'historique ?",
         confirmLabel:'Confirmer',
-        cancelLabel:'Revenir en arrière',
+        cancelLabel:'Annuler',
         onConfirm: ()=>{
           localStorage.removeItem('tbmEntries');
           loadHistory();


### PR DESCRIPTION
### Motivation
- Clarifier et standardiser le libellé du bouton d'annulation dans la fenêtre de confirmation de vidage d'historique en remplaçant une formulation longue par une plus concise.

### Description
- Remplacement de la valeur `cancelLabel` dans `tbm.html` de `'Revenir en arrière'` vers `'Annuler'` (affecte la modal de confirmation du bouton de vidage d'historique).

### Testing
- Aucun test automatisé exécuté car il s'agit d'une modification textuelle de l'interface utilisateur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de326c0b9c8323af5bb9964879462c)