### PR TITLE
Update clear-history confirmation cancel label in TBM modal

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -895,7 +895,7 @@
       showConfirmation({
         message:"Voulez-vous vraiment vider l'historique ?",
         confirmLabel:'Confirmer',
-        cancelLabel:'Revenir en arrière',
+        cancelLabel:'Annuler',
         onConfirm: ()=>{
           localStorage.removeItem('tbmEntries');
           loadHistory();


### PR DESCRIPTION
### Motivation
- Replace the cancel button text in the confirmation dialog shown when clicking "Vider l'historique" to use a clearer, shorter label (`Annuler` instead of `Revenir en arrière`).

### Description
- Change in `tbm.html`: update the clear-history confirmation options from `cancelLabel:'Revenir en arrière'` to `cancelLabel:'Annuler'` so the modal cancel button reads "Annuler".

### Testing
- Verified the change by searching the file with `rg -n "cancelLabel:'Annuler'|Revenir en arrière" tbm.html` and inspecting the relevant lines with `nl -ba tbm.html | sed -n '888,906p'`, both confirming the new label is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de42e21a2c832383c0045b31b35e3e)