### PR TITLE
Remplacer le libellé 'Équipe' par 'Participants présents' dans tbm.html

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -76,7 +76,7 @@
 
     <section class="bg-white rounded shadow p-4">
       <div class="flex justify-between items-center mb-2">
-        <label class="text-sm font-medium">Équipe</label>
+        <label class="text-sm font-medium">Participants présents</label>
         <button id="toggleAll" class="text-sm text-blue-600 underline">Tout cocher</button>
       </div>
       <div id="teamContainer" class="flex flex-col gap-1 mb-2"></div>


### PR DESCRIPTION
### Motivation
- Clarifier le libellé du formulaire TBM en remplaçant «Équipe» par «Participants présents» pour refléter précisément le champ.

### Description
- Remplacement du texte du label dans `tbm.html` : `Équipe` → `Participants présents`, sans modification du comportement ou de la logique.

### Testing
- Vérification automatisée du texte modifié avec `rg -n "Équipe|Participants présents" tbm.html` et inspection des lignes mises à jour avec `nl -ba tbm.html | sed -n '72,84p'`, qui confirment la nouvelle étiquette.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4538c18c8323a26a84da279f332a)