### PR TITLE
Persist TBM métier/chantier/responsable selections across sessions

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -149,6 +149,7 @@
     // URL Apps Script (collect TBM)
     const COLLECT_URL = "https://script.google.com/macros/s/AKfycbwLRqxxGrcsW73R-iMHDbbKFchA2V6Xw5uUZmuo1qVW_DBW8KerO3GD2FRge7xPo-hbjw/exec";
     const OUTBOX_KEY = 'tbm_outbox_v1';
+    const FORM_PREFS_KEY = 'tbm_form_prefs_v1';
 
     const loadStatus = document.getElementById('loadStatus');
     const retryBtn = document.getElementById('retryBtn');
@@ -197,6 +198,26 @@
     const normalizedNameMap = new Map();
     let lastVideoUrl = '';
     let hasAttemptedSubmit = false;
+    let formPrefs = { metier: '', chantier: '', responsable: '' };
+
+    function loadFormPrefs(){
+      try{
+        const raw = JSON.parse(localStorage.getItem(FORM_PREFS_KEY) || '{}');
+        formPrefs = {
+          metier: (raw.metier || '').toString(),
+          chantier: (raw.chantier || '').toString(),
+          responsable: (raw.responsable || '').toString()
+        };
+      }catch{
+        formPrefs = { metier: '', chantier: '', responsable: '' };
+      }
+    }
+
+    function saveFormPrefs(){
+      try{
+        localStorage.setItem(FORM_PREFS_KEY, JSON.stringify(formPrefs));
+      }catch{}
+    }
 
     function markInvalidField(element, invalid){
       if(!element) return;
@@ -430,7 +451,9 @@
       setSelectOptions(chantierSelect, chantiers);
 
       if(chantiers.length){
-        chantierSelect.value = chantiers[0];
+        chantierSelect.value = chantiers.includes(formPrefs.chantier) ? formPrefs.chantier : chantiers[0];
+        formPrefs.chantier = chantierSelect.value;
+        saveFormPrefs();
         populateResponsablesForChantier();
       }
     }
@@ -463,7 +486,9 @@
         setSelectOptions(responsableSelect, responsibles);
         responsableSelect.disabled = !!responsableManualInput.value.trim();
         if(!responsableSelect.disabled){
-          responsableSelect.value = responsibles[0];
+          responsableSelect.value = responsibles.includes(formPrefs.responsable) ? formPrefs.responsable : responsibles[0];
+          formPrefs.responsable = responsableSelect.value;
+          saveFormPrefs();
         }
       }else{
         responsableSelect.disabled=true;
@@ -570,6 +595,8 @@
       metierInput.value = '';
       chantierManualInput.value = '';
       responsableManualInput.value = '';
+      formPrefs = { metier: '', chantier: '', responsable: '' };
+      localStorage.removeItem(FORM_PREFS_KEY);
       chantierSelect.value = '';
       responsableSelect.value = '';
       manualInput.value = '';
@@ -734,9 +761,24 @@
     teamContainer.addEventListener('change', ()=>{ if(hasAttemptedSubmit) validateRequiredFields(true); });
 
     // ✅ listeners
-    metierInput.addEventListener('change', ()=>{ updateAll(); if(hasAttemptedSubmit) validateRequiredFields(true); });
-    chantierSelect.addEventListener('change', ()=>{ populateResponsablesForChantier(); if(hasAttemptedSubmit) validateRequiredFields(true); });
-    responsableSelect.addEventListener('change', ()=>{ populateTeamForSelectedResponsable(); if(hasAttemptedSubmit) validateRequiredFields(true); });
+    metierInput.addEventListener('change', ()=>{
+      formPrefs.metier = metierInput.value;
+      saveFormPrefs();
+      updateAll();
+      if(hasAttemptedSubmit) validateRequiredFields(true);
+    });
+    chantierSelect.addEventListener('change', ()=>{
+      formPrefs.chantier = chantierSelect.value;
+      saveFormPrefs();
+      populateResponsablesForChantier();
+      if(hasAttemptedSubmit) validateRequiredFields(true);
+    });
+    responsableSelect.addEventListener('change', ()=>{
+      formPrefs.responsable = responsableSelect.value;
+      saveFormPrefs();
+      populateTeamForSelectedResponsable();
+      if(hasAttemptedSubmit) validateRequiredFields(true);
+    });
 
     chantierManualInput.addEventListener('input',()=>{
       if(chantierManualInput.value.trim()){
@@ -934,7 +976,11 @@
     function init(){
       const now=new Date();
       now.setMinutes(now.getMinutes()-now.getTimezoneOffset());
+      loadFormPrefs();
       dateInput.value=now.toISOString().slice(0,16);
+      if(formPrefs.metier){
+        metierInput.value = formPrefs.metier;
+      }
       updateWeekHint();
       flushQueue();
       loadHistory();


### PR DESCRIPTION
### Motivation
- Users should not have to reselect `métier`, `chantier` and `responsable` each time they open the TBM page, so form choices must be remembered across sessions.

### Description
- Added a `FORM_PREFS_KEY` (`tbm_form_prefs_v1`) and a `formPrefs` object to `tbm.html` and implemented `loadFormPrefs()` and `saveFormPrefs()` to read/write preferences to `localStorage`.
- Restored saved `metier` on initialization and reused saved `chantier`/`responsable` when repopulating dependent selects, falling back to the first available option when the saved value is not present.
- Updated the `change` listeners for `metier`, `chantier` and `responsable` to persist selections immediately and updated the logic that sets default select values to also persist the chosen defaults.
- Cleared the saved preferences in `resetFormData()` so the `Reset données` button returns the form to a fully clean state.

### Testing
- Ran `git diff --check` and it returned `OK`, indicating no patch formatting/errors.
- Verified the modified `tbm.html` was updated and contains the new `FORM_PREFS_KEY` usage and persistence functions by inspecting the file changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4c6967fc8323889dcd149cebda5b)