### PR TITLE
Responsable: add manual “Valider” button and clear dropdown on manual entry

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -62,7 +62,10 @@
     <section class="bg-white rounded shadow p-4">
       <label for="responsableSelect" class="block text-sm font-medium mb-1">3. Responsable (CE/SiSu)</label>
       <select id="responsableSelect" class="border rounded px-2 py-1 w-full"></select>
-      <input id="responsableManual" type="text" class="border rounded px-2 py-1 w-full mt-1 text-sm" placeholder="Ajouter manuellement">
+      <div class="flex gap-2 mt-1">
+        <input id="responsableManual" type="text" class="border rounded px-2 py-1 flex-1 text-sm" placeholder="Ajouter manuellement">
+        <button id="responsableManualBtn" type="button" class="px-3 py-1 bg-blue-600 text-white rounded text-sm">Valider</button>
+      </div>
       <p id="responsableHelper" class="text-sm text-gray-500 mt-1"></p>
     </section>
 
@@ -160,6 +163,7 @@
     const responsableSelect = document.getElementById('responsableSelect');
     const chantierManualInput = document.getElementById('chantierManual');
     const responsableManualInput = document.getElementById('responsableManual');
+    const responsableManualBtn = document.getElementById('responsableManualBtn');
     const responsableHelper = document.getElementById('responsableHelper');
 
     const teamContainer = document.getElementById('teamContainer');
@@ -510,6 +514,19 @@
       });
     }
 
+    function applyManualResponsable(){
+      const manualResponsable = responsableManualInput.value.trim();
+      if(!manualResponsable){
+        responsableHelper.textContent = '';
+        return false;
+      }
+      responsableSelect.value = '';
+      responsableSelect.disabled = true;
+      responsableHelper.textContent = 'Responsable manuel validé';
+      populateTeamForSelectedResponsable();
+      return true;
+    }
+
     function populateVideo(){
       thumbContainer.innerHTML='Vidéo non disponible';
       qrcodeEl.innerHTML='';
@@ -763,13 +780,27 @@
 
     responsableManualInput.addEventListener('input',()=>{
       if(responsableManualInput.value.trim()){
+        responsableSelect.value='';
         responsableSelect.disabled=true;
         responsableHelper.textContent='';
       }else{
         responsableSelect.disabled=false;
+        populateResponsablesForChantier();
       }
       populateTeamForSelectedResponsable();
       if(hasAttemptedSubmit) validateRequiredFields(true);
+    });
+    responsableManualInput.addEventListener('keydown',e=>{
+      if(e.key==='Enter'){
+        e.preventDefault();
+        applyManualResponsable();
+        if(hasAttemptedSubmit) validateRequiredFields(true);
+      }
+    });
+    responsableManualBtn.addEventListener('click',()=>{
+      applyManualResponsable();
+      if(hasAttemptedSubmit) validateRequiredFields(true);
+      responsableManualInput.focus();
     });
 
     dateInput.addEventListener('change', ()=>{ updateAll(); if(hasAttemptedSubmit) validateRequiredFields(true); });


### PR DESCRIPTION
### Motivation
- Permettre la saisie manuelle d’un responsable avec confirmation explicite et s’assurer que la sélection existante est effacée quand un nom est saisi manuellement.

### Description
- Ajout du bouton de validation en UI à côté du champ manuel `responsableManual` (`responsableManualBtn`) et restructuration légère du HTML pour le groupement du champ et du bouton.
- Ajout de la récupération DOM de `responsableManualBtn` et d’une fonction `applyManualResponsable()` qui désactive et vide le `responsableSelect`, affiche un message d’aide et recharge l’équipe via `populateTeamForSelectedResponsable()`.
- Ajout de la gestion de la touche `Enter` sur le champ `responsableManual` et d’un gestionnaire `click` sur le bouton pour appeler `applyManualResponsable()` et maintenir la validation des champs si nécessaire.
- Lors de la saisie manuelle vide, la liste déroulante des responsables est réactivée et rechargée via `populateResponsablesForChantier()` pour restaurer le comportement initial.

### Testing
- Exécuté `git diff --check` qui est passé proprement (aucune erreur signalée).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5459b1188323aebbbd673446db39)