### PR TITLE
Fix message de validation du Responsable dans tbm.html

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -522,7 +522,7 @@
       }
       responsableSelect.value = '';
       responsableSelect.disabled = true;
-      responsableHelper.textContent = 'Responsable manuel validé';
+      responsableHelper.textContent = 'Responsable validé';
       populateTeamForSelectedResponsable();
       return true;
     }


### PR DESCRIPTION
### Motivation
- Standardiser le message d'aide affiché après la validation manuelle du responsable pour qu'il indique « Responsable validé » au lieu de « Responsable manuel validé ». 

### Description
- Remplacement du texte dans la fonction `applyManualResponsable()` de `tbm.html` : `'Responsable manuel validé'` → `'Responsable validé'`.

### Testing
- Aucun test automatisé n'a été exécuté pour ce changement purement textuel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df57215bd08323bb86b89c6e13f1c2)