### PR TITLE
Update TBM UI numbering labels in tbm.html

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -75,14 +75,14 @@
         <div id="qrcode" class="w-32 h-32"></div>
       </div>
       <div class="mt-2 flex gap-2">
-        <button id="playBtn" class="px-3 py-1 bg-blue-600 text-white rounded disabled:opacity-50">Lire la vidéo</button>
+        <button id="playBtn" class="px-3 py-1 bg-blue-600 text-white rounded disabled:opacity-50">4.Lire la vidéo</button>
         <button id="copyLink" class="px-3 py-1 bg-blue-600 text-white rounded disabled:opacity-50">Copier le lien</button>
       </div>
     </section>
 
     <section class="bg-white rounded shadow p-4">
       <div class="flex justify-between items-center mb-2">
-        <label class="text-sm font-medium">4.Participants présents</label>
+        <label class="text-sm font-medium">5.Participants présents</label>
         <button id="toggleAll" class="text-sm text-blue-600 underline">Tout cocher</button>
       </div>
       <div id="teamContainer" class="flex flex-col gap-1 mb-2"></div>
@@ -99,7 +99,7 @@
     </section>
 
     <section class="bg-white rounded shadow p-4">
-      <button id="sendBtn" class="px-3 py-1 bg-black text-white rounded w-full">Envoyer</button>
+      <button id="sendBtn" class="px-3 py-1 bg-black text-white rounded w-full">6.Envoyer</button>
       <p id="sendStatus" class="text-sm mt-1"></p>
     </section>
 


### PR DESCRIPTION
### Motivation
- Align on-screen step numbering in the TBM UI by updating three literal labels in the static HTML.

### Description
- In `tbm.html` replaced `Lire la vidéo` with `4.Lire la vidéo`, `4.Participants présents` with `5.Participants présents`, and `Envoyer` with `6.Envoyer`.

### Testing
- No automated tests were run for this text-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5a04aa54832393c0dc97b910c3bd)