### PR TITLE
Add mobile-friendly help icon and accessible help modal to TBM page

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -31,6 +31,18 @@
 
   <main class="space-y-4 max-w-md mx-auto px-4 py-4">
     <h1 class="text-2xl font-bold mb-4 px-4 py-2 rounded-xl bg-[#104861] text-[#D9D9D9] text-center">TBM</h1>
+    <div class="flex justify-center -mt-2 mb-2">
+      <!-- Bouton d'aide discret et accessible (mobile-first) -->
+      <button
+        id="tbmHelpBtn"
+        type="button"
+        class="inline-flex items-center justify-center w-9 h-9 rounded-full border border-slate-300 bg-white text-slate-600 text-base font-semibold shadow-sm hover:bg-slate-50 active:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+        aria-label="Afficher l’aide pour compléter un TBM"
+        title="Aide TBM"
+      >
+        <span aria-hidden="true">i</span>
+      </button>
+    </div>
 
     <p id="loadStatus" class="text-sm text-gray-500"></p>
     <div class="flex items-center justify-between">
@@ -132,6 +144,32 @@
     </div>
   </div>
 
+  <div id="tbmHelpModal" class="fixed inset-0 z-20 bg-black/50 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 hidden" role="dialog" aria-modal="true" aria-labelledby="tbmHelpTitle" aria-hidden="true">
+    <div class="bg-white rounded-t-2xl sm:rounded-xl shadow-xl w-full sm:max-w-md max-h-[90vh] overflow-y-auto p-4 sm:p-5">
+      <div class="flex items-start justify-between gap-3 mb-3">
+        <h2 id="tbmHelpTitle" class="text-base sm:text-lg font-semibold text-slate-900">Aide TBM</h2>
+        <button id="tbmHelpCloseIcon" type="button" class="inline-flex items-center justify-center w-9 h-9 rounded-full border border-slate-300 text-slate-600 hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2" aria-label="Fermer la fenêtre d’aide" title="Fermer">
+          <span aria-hidden="true">✕</span>
+        </button>
+      </div>
+      <div class="text-sm text-slate-700 leading-6 space-y-3">
+        <p><strong>Première utilisation ?</strong><br>Voici comment compléter un TBM :</p>
+        <ol class="list-decimal list-inside space-y-2">
+          <li><strong>Métier</strong><br>Choisissez Elec (LLN) ou HVAC-Ref (JumAl) selon votre site.</li>
+          <li><strong>Chantier</strong><br>Sélectionnez votre chantier dans la liste.<br>Vous pouvez aussi l’encoder manuellement si besoin.</li>
+          <li><strong>Responsable (CE / SiSu)</strong><br>Choisissez votre nom dans la liste proposée pour le chantier sélectionné.<br>Vous pouvez aussi l’encoder manuellement.<br>Attention : dans ce cas, la liste des participants ne sera pas chargée automatiquement.</li>
+          <li><strong>TBM</strong><br>Visionnez la vidéo en groupe ou partagez-la via le QR code.</li>
+          <li><strong>Participants présents</strong><br>Cochez uniquement les personnes présentes au TBM.<br>Un nom manque ? Tapez les premières lettres et sélectionnez-le dans la liste proposée.<br>Seuls les noms repris chez VMA Sud peuvent être ajoutés.</li>
+          <li><strong>Envoyer</strong><br>Cliquez sur Envoyer puis confirmez l’envoi 👍</li>
+        </ol>
+        <p><strong>Bon à savoir</strong><br>La date et l’heure sont générées automatiquement.</p>
+      </div>
+      <div class="mt-4 flex justify-end">
+        <button id="tbmHelpCloseBtn" type="button" class="px-4 py-2 bg-slate-900 text-white rounded-lg text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2">Fermer</button>
+      </div>
+    </div>
+  </div>
+
   <script>
     const LANG_KEY = "qhse_lang_v1";
     function setLang(l){
@@ -193,6 +231,10 @@
     const confirmationMessage = confirmationModal.querySelector('[data-modal-message]');
     const successModal = document.getElementById('successModal');
     const closeSuccessModalBtn = document.getElementById('closeSuccessModal');
+    const tbmHelpBtn = document.getElementById('tbmHelpBtn');
+    const tbmHelpModal = document.getElementById('tbmHelpModal');
+    const tbmHelpCloseIcon = document.getElementById('tbmHelpCloseIcon');
+    const tbmHelpCloseBtn = document.getElementById('tbmHelpCloseBtn');
 
     let affectRows = [];
     let tbmData = null;
@@ -410,7 +452,7 @@
 
       const base = getFilteredRowsBase();
       if(!base.length){
-        loadStatus.textContent = 'Sélectionnez un métier + une date (semaine)';
+        loadStatus.textContent = '';
         chantierSelect.disabled=true;
         responsableSelect.disabled=true;
         teamContainer.innerHTML='';
@@ -854,6 +896,24 @@
       if(returnFocus) sendBtn.focus();
     }
 
+    // Modale d'aide TBM : ouverture/fermeture simple et accessible
+    let lastFocusedHelpTrigger = null;
+    function showHelpModal(){
+      lastFocusedHelpTrigger = document.activeElement;
+      tbmHelpModal.classList.remove('hidden');
+      tbmHelpModal.setAttribute('aria-hidden', 'false');
+      tbmHelpCloseIcon.focus();
+    }
+    function hideHelpModal(){
+      tbmHelpModal.classList.add('hidden');
+      tbmHelpModal.setAttribute('aria-hidden', 'true');
+      if(lastFocusedHelpTrigger && typeof lastFocusedHelpTrigger.focus === 'function'){
+        lastFocusedHelpTrigger.focus();
+      }else{
+        tbmHelpBtn.focus();
+      }
+    }
+
     async function submitPayload(payload){
       sendBtn.disabled = true;
       const originalLabel = sendBtn.textContent;
@@ -902,10 +962,15 @@
     confirmationModal.addEventListener('click', (ev)=>{ if(ev.target === confirmationModal) hideConfirmation(); });
     closeSuccessModalBtn.addEventListener('click', ()=> hideSuccessModal());
     successModal.addEventListener('click', (ev)=>{ if(ev.target === successModal) hideSuccessModal(); });
+    tbmHelpBtn.addEventListener('click', ()=> showHelpModal());
+    tbmHelpCloseIcon.addEventListener('click', ()=> hideHelpModal());
+    tbmHelpCloseBtn.addEventListener('click', ()=> hideHelpModal());
+    tbmHelpModal.addEventListener('click', (ev)=>{ if(ev.target === tbmHelpModal) hideHelpModal(); });
     document.addEventListener('keydown', (ev)=>{
       if(ev.key !== 'Escape') return;
       if(!confirmationModal.classList.contains('hidden')) hideConfirmation();
       else if(!successModal.classList.contains('hidden')) hideSuccessModal();
+      else if(!tbmHelpModal.classList.contains('hidden')) hideHelpModal();
     });
 
     sendBtn.addEventListener('click',()=>{


### PR DESCRIPTION
### Motivation
- Clean up the UI under the `TBM` heading by replacing the inline instruction text with a discreet, mobile-first help affordance. 
- Provide a compact, accessible place to show the full onboarding steps without touching the business logic or breaking existing flows.

### Description
- Inserted a circular help button (`#tbmHelpBtn`) centered under the `TBM` heading with Tailwind styling and accessible attributes (`aria-label`, `title`, focus-visible styles). 
- Added a mobile-friendly help dialog (`#tbmHelpModal`) that acts as a bottom-sheet on small screens and a centered dialog on larger screens, containing the supplied TBM instructions and a clear close icon and `Fermer` button. 
- Wired minimal vanilla JS handlers (`showHelpModal` / `hideHelpModal`) to manage open/close, backdrop click, Escape-key close and focus restoration to the trigger for accessibility. 
- Stopped showing the previous inline instruction string from the `loadStatus` path so help is delivered exclusively via the new component.

### Testing
- Static verification with `rg`/file inspection confirmed the new IDs and functions (`tbmHelpBtn`, `tbmHelpModal`, `showHelpModal`, `hideHelpModal`) are present in `tbm.html` and the modal markup is inserted in the expected location. 
- `nl`/file preview output shows the help markup and JS handlers at the intended lines and the prior instruction string was cleared where applicable. 
- No automated unit/UI tests exist for this page in the repo; visual verification/screenshot was not produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5bdb38ec8323911b2794bafb195b)