### PR TITLE
Make TBM help icon blue and add left-aligned quick‑guide label

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -31,17 +31,18 @@
 
   <main class="space-y-4 max-w-md mx-auto px-4 py-4">
     <h1 class="text-2xl font-bold mb-4 px-4 py-2 rounded-xl bg-[#104861] text-[#D9D9D9] text-center">TBM</h1>
-    <div class="flex justify-center -mt-2 mb-2">
+    <div class="flex items-center justify-start gap-2 -mt-2 mb-2">
       <!-- Bouton d'aide discret et accessible (mobile-first) -->
       <button
         id="tbmHelpBtn"
         type="button"
-        class="inline-flex items-center justify-center w-9 h-9 rounded-full border border-slate-300 bg-white text-slate-600 text-base font-semibold shadow-sm hover:bg-slate-50 active:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+        class="inline-flex items-center justify-center w-9 h-9 rounded-full border border-blue-700 bg-blue-700 text-white text-base font-semibold shadow-sm hover:bg-blue-800 active:bg-blue-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
         aria-label="Afficher l’aide pour compléter un TBM"
         title="Aide TBM"
       >
         <span aria-hidden="true">i</span>
       </button>
+      <span class="text-sm font-medium text-slate-700">Guide rapide d'utilisation</span>
     </div>
 
     <p id="loadStatus" class="text-sm text-gray-500"></p>


### PR DESCRIPTION
### Motivation
- Improve visibility and alignment of the TBM help control by turning the info button into a blue circular indicator and placing a short label next to it for quicker discovery.

### Description
- In `tbm.html` the help control container was changed from centered to left-aligned and the help button classes were updated to use a blue background with white text, and a `span` with the text `Guide rapide d'utilisation` was added next to the button.

### Testing
- No automated tests were run for this UI-only HTML/CSS adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5eb7e5448323a897c5d00b9aa27a)