### PR TITLE
Remove 'Tout cocher' option from TBM participants

### DIFF
--- a/tbm.html
+++ b/tbm.html
@@ -96,7 +96,6 @@
     <section class="bg-white rounded shadow p-4">
       <div class="flex justify-between items-center mb-2">
         <label class="text-sm font-medium">5.Participants présents</label>
-        <button id="toggleAll" class="text-sm text-blue-600 underline">Tout cocher</button>
       </div>
       <div id="teamContainer" class="flex flex-col gap-1 mb-2"></div>
 
@@ -206,7 +205,6 @@
     const responsableHelper = document.getElementById('responsableHelper');
 
     const teamContainer = document.getElementById('teamContainer');
-    const toggleAllBtn = document.getElementById('toggleAll');
     const manualInput = document.getElementById('manualInput');
     const manualChips = document.getElementById('manualChips');
     const manualAddBtn = document.getElementById('manualAddBtn');
@@ -784,12 +782,6 @@
     retryBtn.addEventListener('click', loadSheets);
     resetBtn.addEventListener('click', resetFormData);
 
-    toggleAllBtn.addEventListener('click',()=>{
-      const boxes = teamContainer.querySelectorAll('input[type="checkbox"]');
-      const allChecked = Array.from(boxes).every(b=>b.checked);
-      boxes.forEach(b=>b.checked=!allChecked);
-      if(hasAttemptedSubmit) validateRequiredFields(true);
-    });
     teamContainer.addEventListener('change', ()=>{ if(hasAttemptedSubmit) validateRequiredFields(true); });
 
     // ✅ listeners


### PR DESCRIPTION
### Motivation
- Supprimer l’option d’action en masse qui permettait de cocher/décocher tous les participants dans le formulaire TBM pour éviter les sélections globales accidentelles.

### Description
- Enlevé le bouton `Tout cocher` depuis la section `5.Participants présents` de `tbm.html`.
- Retirée la référence DOM `const toggleAllBtn = document.getElementById('toggleAll');` de l'initialisation du script.
- Supprimé le gestionnaire `click` qui basculait l'état de toutes les cases à cocher des participants.

### Testing
- Exécuté `rg -n "toggleAll|Tout cocher" tbm.html` pour vérifier l'absence des occurrences, résultat attendu (aucune occurrence trouvée) — réussi.
- Inspecté le diff avec `git diff -- tbm.html` puis engagé les changements avec `git commit -m "Remove 'Tout cocher' option from TBM participants"`, commit créé — réussi.
- Aucun test d'interface ou runtime automatisé n'a été exécuté puisque il s'agit d'un changement purement HTML/JS côté client.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73d6d40188323b2f04fedf189dbd3)