### PR TITLE
Auto-validate selected Responsable in Participants list (TBM)

### DIFF
--- a/cypress/e2e/tbm_responsable_participant.cy.js
+++ b/cypress/e2e/tbm_responsable_participant.cy.js
@@ -1,0 +1,47 @@
+function currentIsoWeek() {
+  const date = new Date();
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const day = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+  return Math.ceil((((utcDate - yearStart) / 86400000) + 1) / 7);
+}
+
+describe('TBM responsable participant', () => {
+  it('checks and validates the selected responsable in the participants list', () => {
+    const week = currentIsoWeek();
+    const affectations = [
+      'annee,semaine,pm,sisu,ce,ouvrier,chantier,nbcolonnes,sheet,row',
+      `2026,${week},,,Alice Responsable,Ouvrier Un,Chantier Test,1,EQUIPE_ELEC,1`,
+      `2026,${week},,,Bob Responsable,Ouvrier Deux,Chantier Test,1,EQUIPE_ELEC,2`,
+    ].join('\n');
+
+    cy.intercept('GET', '**gid=496527492**', {
+      statusCode: 200,
+      headers: { 'content-type': 'text/csv' },
+      body: affectations,
+    });
+    cy.intercept('GET', '**gid=2013584163**', {
+      statusCode: 200,
+      headers: { 'content-type': 'text/csv' },
+      body: 'mois,url',
+    });
+
+    cy.visit('tbm.html');
+    cy.get('#metier').select('Elec');
+
+    cy.get('#responsableSelect').select('Alice Responsable');
+    cy.get('#teamContainer input[data-responsable="true"]')
+      .should('have.value', 'Alice Responsable')
+      .and('be.checked')
+      .and('be.disabled');
+    cy.get('#teamContainer').should('contain.text', 'Responsable validé');
+    cy.get('#teamContainer input[value="Ouvrier Un"]').should('not.be.checked');
+
+    cy.get('#responsableSelect').select('Bob Responsable');
+    cy.get('#teamContainer input[data-responsable="true"]')
+      .should('have.value', 'Bob Responsable')
+      .and('be.checked');
+    cy.get('#teamContainer input[value="Alice Responsable"]').should('not.exist');
+  });
+});

--- a/tbm.html
+++ b/tbm.html
@@ -537,6 +537,7 @@
       if(!selectedResp) return;
 
       const respTarget = normUpper(selectedResp);
+      const responsableFromList = !responsableManualInput.value.trim() && !responsableSelect.disabled;
 
       const members = uniqSorted(
         chantierRows
@@ -545,12 +546,31 @@
           .filter(Boolean)
       );
 
-      members.forEach(n=>{
+      // Le responsable choisi dans la liste participe obligatoirement au TBM.
+      // On l'affiche en premier et on évite un doublon s'il figure aussi comme ouvrier.
+      const displayedMembers = responsableFromList
+        ? [selectedResp, ...members.filter(n => normUpper(n) !== respTarget)]
+        : members;
+
+      displayedMembers.forEach(n=>{
+        const isSelectedResponsable = responsableFromList && normUpper(n) === respTarget;
         const lbl=document.createElement('label');
         lbl.className='inline-flex items-center gap-2';
         const cb=document.createElement('input');
         cb.type='checkbox'; cb.value=n; cb.className='rounded';
+        if(isSelectedResponsable){
+          cb.checked=true;
+          cb.disabled=true;
+          cb.dataset.responsable='true';
+          cb.setAttribute('aria-label', `${n}, responsable présent et validé`);
+        }
         lbl.appendChild(cb); lbl.append(n);
+        if(isSelectedResponsable){
+          const validated=document.createElement('span');
+          validated.className='text-xs font-medium text-green-700';
+          validated.textContent='Responsable validé';
+          lbl.appendChild(validated);
+        }
         teamContainer.appendChild(lbl);
       });
     }


### PR DESCRIPTION
### Motivation
- Garantir que le chef d'équipe choisi dans « 3. Responsable (CE/SiSu) » soit automatiquement présent, coché et validé dans la section « 5. Participants présents » pour éviter les oublis et garantir son inclusion dans les données envoyées.

### Description
- Dans `tbm.html` la fonction `populateTeamForSelectedResponsable()` ajoute le responsable sélectionné en tête de la liste des participants, évite les doublons si le responsable apparaît aussi comme ouvrier, et affiche la liste réordonnée.
- Le checkbox correspondant au responsable est automatiquement coché et désactivé, reçoit l'attribut `data-responsable` et un `aria-label`, et un badge texte « Responsable validé » est ajouté pour l'indication visuelle et accessibilité.
- L'auto-validation s'applique uniquement lorsque le responsable est choisi depuis la liste (et non lors d'une saisie manuelle).
- Ajout d'un test Cypress `cypress/e2e/tbm_responsable_participant.cy.js` qui couvre la sélection du responsable, la présence du checkbox coché/verrouillé et le comportement lors du changement de responsable.

### Testing
- Exécution de `npm run build` réussie sans erreurs.
- Vérification statique `node --check /tmp/tbm-inline.mjs` et `git diff --check` passées sans erreurs.
- Tentative d'exécution du test E2E `npx cypress run --spec cypress/e2e/tbm_responsable_participant.cy.js` interrompue car Cypress n'a pas pu démarrer en raison de l'absence de `Xvfb` dans l'environnement (test non exécuté ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ee7b0b2a4832388250b4aec7e3bf0)